### PR TITLE
Update build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,8 +2,13 @@
 
 buildscript {
     repositories {
-        jcenter()
+        maven {
+            url "https://maven.google.com"
+        }
         google()
+        mavenCentral()
+        jcenter()
+
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'
@@ -15,7 +20,8 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
         google()
+        mavenCentral();
+        jcenter()
     }
 }


### PR DESCRIPTION
Jcenter no longer hosts google dependencies, these can be resolved from "https://maven.google.com"